### PR TITLE
fix: Replaced using compileSdkVersion as targetSdkVersion

### DIFF
--- a/stonecraft-orm/build.gradle
+++ b/stonecraft-orm/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
-def libVersion = '1.7.1'
+def libVersion = '1.7.2'
 
 def getExtOrDefault(name, defaultValue) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : defaultValue

--- a/stonecraft-orm/build.gradle
+++ b/stonecraft-orm/build.gradle
@@ -9,6 +9,10 @@ apply plugin: 'kotlin-kapt'
 
 def libVersion = '1.7.1'
 
+def getExtOrDefault(name, defaultValue) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : defaultValue
+}
+
 android {
     compileSdkVersion 30
     resourcePrefix "stonecraft_"
@@ -19,8 +23,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion compileSdkVersion
+        minSdkVersion getExtOrDefault('minSdkVersion', 21)
+        targetSdkVersion getExtOrDefault('targetSdkVersion', 30)
         versionCode 9
         versionName libVersion
     }


### PR DESCRIPTION
Using compileSdkVersion as targetSdkVersion will result to "android-30" instead of 30.
Also added way to get the rootProject's minSdkVersion and targetSdkVersion 